### PR TITLE
Fix ESP32 Warning

### DIFF
--- a/Adafruit_SHT4x.cpp
+++ b/Adafruit_SHT4x.cpp
@@ -29,6 +29,8 @@
 
 #include "Adafruit_SHT4x.h"
 
+static uint8_t crc8(const uint8_t *data, int len);
+
 /*!
  * @brief  SHT4x constructor
  */
@@ -373,7 +375,7 @@ bool Adafruit_SHT4x::readCommand(uint16_t command, uint8_t *buffer,
  *
  * @return The computed CRC8 value.
  */
-uint8_t crc8(const uint8_t *data, int len) {
+static uint8_t crc8(const uint8_t *data, int len) {
   /*
    *
    * CRC-8 formula from page 14 of SHT spec pdf

--- a/Adafruit_SHT4x.cpp
+++ b/Adafruit_SHT4x.cpp
@@ -373,7 +373,7 @@ bool Adafruit_SHT4x::readCommand(uint16_t command, uint8_t *buffer,
  *
  * @return The computed CRC8 value.
  */
-static uint8_t crc8(const uint8_t *data, int len) {
+uint8_t crc8(const uint8_t *data, int len) {
   /*
    *
    * CRC-8 formula from page 14 of SHT spec pdf

--- a/Adafruit_SHT4x.h
+++ b/Adafruit_SHT4x.h
@@ -48,8 +48,6 @@
 #define SHT4x_READSERIAL 0x89 /**< Read Out of Serial Register */
 #define SHT4x_SOFTRESET 0x94  /**< Soft Reset */
 
-static uint8_t crc8(const uint8_t *data, int len);
-
 /** How precise (repeatable) the measurement will be */
 typedef enum {
   SHT4X_HIGH_PRECISION,

--- a/Adafruit_SHT4x.h
+++ b/Adafruit_SHT4x.h
@@ -48,7 +48,7 @@
 #define SHT4x_READSERIAL 0x89 /**< Read Out of Serial Register */
 #define SHT4x_SOFTRESET 0x94  /**< Soft Reset */
 
-static inline uint8_t crc8(const uint8_t *data, int len);
+uint8_t crc8(const uint8_t *data, int len);
 
 /** How precise (repeatable) the measurement will be */
 typedef enum {

--- a/Adafruit_SHT4x.h
+++ b/Adafruit_SHT4x.h
@@ -48,8 +48,6 @@
 #define SHT4x_READSERIAL 0x89 /**< Read Out of Serial Register */
 #define SHT4x_SOFTRESET 0x94  /**< Soft Reset */
 
-uint8_t crc8(const uint8_t *data, int len);
-
 /** How precise (repeatable) the measurement will be */
 typedef enum {
   SHT4X_HIGH_PRECISION,

--- a/Adafruit_SHT4x.h
+++ b/Adafruit_SHT4x.h
@@ -48,6 +48,8 @@
 #define SHT4x_READSERIAL 0x89 /**< Read Out of Serial Register */
 #define SHT4x_SOFTRESET 0x94  /**< Soft Reset */
 
+static inline uint8_t crc8(const uint8_t *data, int len);
+
 /** How precise (repeatable) the measurement will be */
 typedef enum {
   SHT4X_HIGH_PRECISION,

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit SHT4x Library
-version=1.0.1
+version=1.0.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for SHT4x temperature & humidity sensor.


### PR DESCRIPTION
Fixes ESP32 GCC warning:
`  /home/runner/Arduino/libraries/Adafruit_SHT4x_Library/Adafruit_SHT4x.h:51:16: error: 'uint8_t crc8(const uint8_t*, int)' declared 'static' but never defined [-Werror=unused-function]
   static uint8_t crc8(const uint8_t *data, int len);`

Tested on hardware, Feather ESP32S2 connected to Adafruit SHT40 Breakout via STEMMA cable