### PR TITLE
Allow address customization

### DIFF
--- a/Adafruit_SHT4x.cpp
+++ b/Adafruit_SHT4x.cpp
@@ -58,7 +58,7 @@ Adafruit_SHT4x::~Adafruit_SHT4x(void) {
  *
  * @return True if initialisation was successful, otherwise False.
  */
-bool Adafruit_SHT4x::begin(TwoWire *theWire) {
+bool Adafruit_SHT4x::begin(TwoWire *theWire, uint8_t address = SHT4x_DEFAULT_ADDR) {
   if (i2c_dev) {
     delete i2c_dev; // remove old interface
   }
@@ -69,7 +69,7 @@ bool Adafruit_SHT4x::begin(TwoWire *theWire) {
     delete humidity_sensor;
   }
 
-  i2c_dev = new Adafruit_I2CDevice(SHT4x_DEFAULT_ADDR, theWire);
+  i2c_dev = new Adafruit_I2CDevice(address, theWire);
 
   if (!i2c_dev->begin()) {
     return false;

--- a/Adafruit_SHT4x.cpp
+++ b/Adafruit_SHT4x.cpp
@@ -55,6 +55,7 @@ Adafruit_SHT4x::~Adafruit_SHT4x(void) {
  * Initialises the I2C bus, and assigns the I2C address to us.
  *
  * @param theWire   The I2C bus to use, defaults to &Wire
+ * @param address   The address to use, defaults to SHT4x_DEFAULT_ADDR (= 0x44)
  *
  * @return True if initialisation was successful, otherwise False.
  */

--- a/Adafruit_SHT4x.cpp
+++ b/Adafruit_SHT4x.cpp
@@ -58,7 +58,7 @@ Adafruit_SHT4x::~Adafruit_SHT4x(void) {
  *
  * @return True if initialisation was successful, otherwise False.
  */
-bool Adafruit_SHT4x::begin(TwoWire *theWire, uint8_t address = SHT4x_DEFAULT_ADDR) {
+bool Adafruit_SHT4x::begin(TwoWire *theWire, uint8_t address) {
   if (i2c_dev) {
     delete i2c_dev; // remove old interface
   }

--- a/Adafruit_SHT4x.h
+++ b/Adafruit_SHT4x.h
@@ -113,7 +113,7 @@ public:
   Adafruit_SHT4x(void);
   ~Adafruit_SHT4x(void);
 
-  bool begin(TwoWire *theWire = &Wire);
+  bool begin(TwoWire *theWire = &Wire, uint8_t address = SHT4x_DEFAULT_ADDR);
   uint32_t readSerial(void);
   bool reset(void);
 


### PR DESCRIPTION
This allows customizing the sensor address. We need `0x46` for sensor variant C.

It might make sense to add additional `#define` for sensor variants B and C.
